### PR TITLE
Queue fire n forget check

### DIFF
--- a/src/Lykke.AzureQueueIntegration/AzureUtils.cs
+++ b/src/Lykke.AzureQueueIntegration/AzureUtils.cs
@@ -6,11 +6,20 @@ namespace Lykke.AzureQueueIntegration
 {
     public static class AzureQueueUtils
     {
-        public static async Task<CloudQueue> GetQueueAsync(this AzureQueueSettings settings)
+        public static async Task<CloudQueue> GetQueueAsync(this AzureQueueSettings settings, 
+            bool fireNForgetExistenceCheck = false)
         {
             var storageAccount = CloudStorageAccount.Parse(settings.ConnectionString);
             var queueClient = storageAccount.CreateCloudQueueClient();
             var queue = queueClient.GetQueueReference(settings.QueueName);
+
+            var checkQueueExistTsk = queue.CreateIfNotExistsAsync();
+
+            if (!fireNForgetExistenceCheck)
+            {
+                await checkQueueExistTsk;
+            }
+
             await queue.CreateIfNotExistsAsync();
             return queue;
         }

--- a/src/Lykke.AzureQueueIntegration/AzureUtils.cs
+++ b/src/Lykke.AzureQueueIntegration/AzureUtils.cs
@@ -19,8 +19,7 @@ namespace Lykke.AzureQueueIntegration
             {
                 await checkQueueExistTsk;
             }
-
-            await queue.CreateIfNotExistsAsync();
+            
             return queue;
         }
     }

--- a/src/Lykke.AzureQueueIntegration/Publisher/AzureQueuePublisher.cs
+++ b/src/Lykke.AzureQueueIntegration/Publisher/AzureQueuePublisher.cs
@@ -58,13 +58,15 @@ namespace Lykke.AzureQueueIntegration.Publisher
         /// <param name="settings">Queue settings</param>
         /// <param name="bufferLifetime">Time interval, which indicates how often buffered messages will be published to the queue</param>
         /// <param name="disableTelemetry">Disables Application Insight telemetry</param>
+        /// <param name="fireNForgetQueueExistenceCheck">Speed up azure queue existence check</param>
         public AzureQueuePublisher(
             [NotNull] ILogFactory logFactory,
             [NotNull] IAzureQueueSerializer<TModel> serializer,
             [NotNull] string publisherName,
             [NotNull] AzureQueueSettings settings,
             TimeSpan? bufferLifetime = null,
-            bool disableTelemetry = true)
+            bool disableTelemetry = true,
+            bool fireNForgetQueueExistenceCheck = false)
             
             : base(bufferLifetime ?? TimeSpan.FromMilliseconds(100), logFactory, publisherName)
         {
@@ -84,7 +86,7 @@ namespace Lykke.AzureQueueIntegration.Publisher
                 ConnectionString = _settings.ConnectionString
             };
 
-            _cloudQueue = _settings.GetQueueAsync().GetAwaiter().GetResult();
+            _cloudQueue = _settings.GetQueueAsync(fireNForgetQueueExistenceCheck).GetAwaiter().GetResult();
 
             if (disableTelemetry)
             {


### PR DESCRIPTION
add ability to create AzureQueuePublisher with 'fire-n-forget existence check' parameter - using this param queue initialization speeds up 3 times. By default behaviour is the same. It is import when initializing muliple publishers at once